### PR TITLE
Update PropTypes for React 16 support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "jsdom": "9.6.0",
     "mocha": "3.1.0",
     "nyc": "8.3.1",
+    "prop-types": "^15.6.1",
     "raf": "3.3.0",
     "react": "15.3.2",
     "react-addons-test-utils": "15.3.2",

--- a/src/ReadMore.js
+++ b/src/ReadMore.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import Truncate from './Truncate';
 
 class ReadMore extends Component {

--- a/src/Truncate.js
+++ b/src/Truncate.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 
 export default class Truncate extends Component {
   static propTypes = {


### PR DESCRIPTION
This pull request should fix #4 and #7. React 16 deprecated using PropTypes from react directly. This has been moved into it's own separate prop-types module.